### PR TITLE
トップページ⇄ユーザー登録ページの遷移を可能に

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,4 +2,8 @@ class UsersController < ApplicationController
   def tsukasa
     render 'ようこそ'
   end
+
+  def new
+    @user = User.new
+  end
 end

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,5 +1,5 @@
 <div class="position-absolute top-50 start-50 translate-middle">
   <h1 class="fw-lighter text-secondary text-center lh-lg">TODO App</h1> 
   <h2 class="fw-lighter  text-secondary text-center lh-lg">自分のTODOを管理しましょう。</h2>
-  <%= button_to '新規登録はこちらから', '#', class:"btn btn-primary d-grid gap-2 col-6 mx-auto lh-lg mt-4"%>
+  <%= link_to '新規登録はこちらから', '/users/new', class:"btn btn-primary d-grid gap-2 col-6 mx-auto lh-lg mt-4"%>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,7 @@
 
 <div class="col-md-6 col-md-offset-3 mx-auto">
     <%= form_for('#') do |f| %>
+
       <%= f.label :name, class: "col-sm-3 control-label" %>
       <%= f.text_field :name, class: "form-control mb-4", placeholder:"User name" %>
 
@@ -13,4 +14,6 @@
 
       <%= f.submit "新規登録", class: 'btn btn-primary d-grid gap-2 col-6 mx-auto'%>
     <% end %>
+
+    <%= link_to "トップページに戻る", '/static_pages/home', class: 'btn btn-success d-grid gap-2 col-6 mx-auto mt-4'%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get 'static_pages/home'
   root 'application#index'
-  get  '/signup',  to: 'users#new'
+  get  '/users/new',  to: 'users#new'
   resources :tasks
+  resources :users
 end


### PR DESCRIPTION
### やったこと
- トップページ⇄ユーザー登録ページの遷移を可能にした

**スクリーンショット**

<img width="1151" alt="スクリーンショット 2022-10-19 17 14 48" src="https://user-images.githubusercontent.com/104341369/196635496-a5e7240f-cab1-45d4-a884-4b9fd2a878fe.png">
↑新規登録ボタン押すと

<img width="1148" alt="スクリーンショット 2022-10-19 17 14 39" src="https://user-images.githubusercontent.com/104341369/196635632-966c5fd6-bb04-49f7-b8d5-534b21cfa74d.png">
↑ユーザー登録ページに移動。`トップページに戻る`押すとトップページに戻る

