### PR TITLE
ログインページの作成

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,19 @@
+<h1 class="fw-lighter text-center">Log in</h1>
+
+<div class="col-md-6 col-md-offset-3 mx-auto">
+    <%= form_for('#') do |f| %>
+    
+      <%= f.label :email, class: "col-sm-3 control-label" %>
+      <%= f.text_field :email_field, class: "form-control mb-4", placeholder:"name@example.co.jp"%>
+   
+      <%= f.label :password, class: "col-sm-3 control-label" %>
+      <%= f.password_field :password,  class: "form-control mb-4", placeholder:"password"%>
+
+      <%= f.submit "ログインする", class: 'btn btn-primary d-grid gap-2 col-6 mx-auto'%>
+    <% end %>
+
+    <%= link_to "トップページに戻る", '/static_pages/home', class: 'btn btn-success d-grid gap-2 col-6 mx-auto mt-4'%>
+
+    <p class= "mt-5 text-center">ユーザー登録が済んでいない方は <%= link_to "こちらから", 'users/new' %></p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
+  get 'sessions/new'
   get 'static_pages/home'
   root 'application#index'
   get  '/users/new',  to: 'users#new'
+  get  '/login',   to: 'sessions#new'
   resources :tasks
   resources :users
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get sessions_new_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### やったこと
- ログインページの作成（ログイン処理はまだ）
- `こちらから`を押すと、ユーザー登録画面に戻れる

**スクリーンショット**
<img width="1162" alt="スクリーンショット 2022-10-19 17 44 37" src="https://user-images.githubusercontent.com/104341369/196643143-f4c2786b-f356-4ab8-bc48-aaf2eedd818e.png">
↑`こちらから`を押すと

<img width="1157" alt="スクリーンショット 2022-10-19 17 44 58" src="https://user-images.githubusercontent.com/104341369/196643321-e30131ab-50f6-475e-8a14-36433c902891.png">
↑ユーザー登録画面に戻れる
