### PR TITLE
ログインしていないときのアクセス制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,12 @@ class ApplicationController < ActionController::Base
       render html: "TODOアプリにようこそ"
     end
 
+    def autheniticate_user
+      if current_user==nil
+        flash[:notice]="ログインが必要です"
+        redirect_to("/login")
+      end
+    end
 
     private
    # ログイン済みユーザーかどうか確認

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :autheniticate_user, only: [:index, :show]
 
   def index
     @user = User.all


### PR DESCRIPTION
### やったこと
- ログインしていない場合でもURLを直接入力するとアクセスできてしまうため、ログインユーザーがいない場合にはログインページにリダイレクトする


**スクリーンショット**
<img width="1411" alt="スクリーンショット 2022-10-25 11 04 38" src="https://user-images.githubusercontent.com/104341369/197665113-80693385-ebbc-428c-97d8-3135919b1874.png">
↑ログインしてない状態で/users/1 にアクセスしようとすると

<img width="1375" alt="スクリーンショット 2022-10-25 11 04 53" src="https://user-images.githubusercontent.com/104341369/197665280-33d09079-6a6e-4dda-9de3-0939b218ea0e.png">
↑ログインページにリダイレクトする

ログインしていなければどのページでも同じ挙動になること確認した