### PR TITLE
ログインしている時のアクセス制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
     include SessionsHelper
 
     def index
-      render html: "TODOアプリにようこそ"
+      redirect_to '/static_pages/home'
     end
 
     def autheniticate_user
@@ -11,6 +11,13 @@ class ApplicationController < ActionController::Base
         flash[:notice]="ログインが必要です"
         redirect_to("/login")
       end
+    end
+
+    def forbid_login_user
+      @user = User.find(params[:id])
+        if not @user == current_user
+          redirect_to current_user
+        end
     end
 
     private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :autheniticate_user, only: [:index, :show]
+  before_action :forbid_login_user, only: [:show]
 
   def index
     @user = User.all


### PR DESCRIPTION
### やったこと

- ログイン状態のユーザーが他ユーザーのページを見れないようにした（ログインさえすればURL直打ちで他のユーザーのページ見れていたのを修正）

- ` localhost:3000` 直打ちで/homeに遷移するように変更（ブランチ分けるべきでした）

**動作確認**

- 　`/users/2`で ログイン後、`/users/3`とURL直打ちしたら`/users/2`にリダイレクトする
